### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,15 +1,31 @@
 {
   "name": "genesis-starter-theme",
-  "homepage": "https://craigsimpson.scot/",
   "version": "1.0.0",
-  "author": "Craig Simpson <craig@craigsimpson.scot>",
-  "description": "This is my starter theme for creating custom websites using the Genesis Framework.",
-  "repository": "https://github.com/craigsimps/genesis-starter-theme.git",
+  "description": "Child theme for creating custom websites using the Genesis Framework.",
+  "homepage": "https://craigsimpson.scot/",
+  "keywords": [
+    "Project Name",
+    "Genesis",
+    "WordPress",
+    "child theme"
+  ],
+  "bugs": {
+    "url": "https://github.com/craigsimps/genesis-starter-theme/issues"
+  },
   "license": "GPL-2.0",
-  "main": "Gulpfile.js",
+  "author": "Craig Simpson <craig@craigsimpson.scot>",
+  "repository": "https://github.com/craigsimps/genesis-starter-theme.git",
   "devDependencies": {
     "gulp": "^3.9.1",
     "gulp-stats": "^0.0.4",
     "gulp-wp-toolkit": "^1.0.2"
+  },
+  "private": true,
+  "theme": {
+    "name": "My Theme",
+    "description": "Child theme for Genesis Framework, for Example.com.",
+    "tags": "See https://make.wordpress.org/themes/handbook/review/required/theme-tags/ for valid tags",
+    "licenseuri": "http://www.opensource.org/licenses/gpl-license.php",
+    "domainpath": "/languages"
   }
 }


### PR DESCRIPTION
The key order is now more aligned to the package.json documentation for convenience. Extra data is added (can easily be removed if not needed). `private` added since most themes won't want to be added to NPM directly. `theme` options added, since some of these values (like name and description) will be visible to the end client, and may not represent what a developer should see.